### PR TITLE
recuperando nome e email do usuario no BD

### DIFF
--- a/app/src/main/java/com/example/projetofirebase/TelaPrincipal.java
+++ b/app/src/main/java/com/example/projetofirebase/TelaPrincipal.java
@@ -1,5 +1,6 @@
 package com.example.projetofirebase;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
@@ -9,11 +10,18 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
 
 public class TelaPrincipal extends AppCompatActivity {
 
     private TextView    textNomeUser, textEmailUser;
     private Button      bt_deslogar;
+    FirebaseFirestore   bd  =   FirebaseFirestore.getInstance();
+    String  usuarioID;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,6 +42,25 @@ public class TelaPrincipal extends AppCompatActivity {
             }
         });
 
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+
+        String  email   =   FirebaseAuth.getInstance().getCurrentUser().getEmail();
+        usuarioID       =   FirebaseAuth.getInstance().getCurrentUser().getUid();
+
+        DocumentReference documentReference =   bd.collection("Usuarios").document(usuarioID);
+        documentReference.addSnapshotListener(new EventListener<DocumentSnapshot>() {
+            @Override
+            public void onEvent(@Nullable DocumentSnapshot documentSnapshot, @Nullable FirebaseFirestoreException error) {
+                if(documentSnapshot != null){
+                    textNomeUser.setText(documentSnapshot.getString("nome"));
+                    textEmailUser.setText(email);
+                }
+            }
+        });
     }
 
     private void IniciarComponentes(){


### PR DESCRIPTION
Pega o nome e o email do usuario(no banco de dados) e adiciona na tela principal e mostra quando o usuario estiver logado.
![Captura de tela 2024-03-08 101905](https://github.com/jesimielsilva/ProjetoFirebase/assets/105837122/901ed2f7-7d93-4289-a26b-5580bcdc2fab)
